### PR TITLE
Save order as a result of the form submission

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -8,12 +8,11 @@ urlpatterns = [
     path('', views.apiOverview, name='api'),
     path('order-list/', views.getActiveOrder, name='order-list'),
     path('order-detail/<str:pk>/', views.orderDetail, name='order-detail'),
-    path('order-create/', views.orderCreate, name='order-create'),
     path('order-update/<str:pk>/', views.orderUpdate, name='order-update'),
     path('order-delete/<str:pk>/', views.orderDelete, name='order-delete'),
 
     path('product-list/', views.getAllProducts, name='product-list'),
     path('popular-products/', views.getMostPopularProducts, name='popular-products'),
-    
+
 ]
 

--- a/api/views.py
+++ b/api/views.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render, get_object_or_404
 from django.http import JsonResponse
 from api.serializers import (
-    OrderSerializer, 
-    ProductSerializer, 
+    OrderSerializer,
+    ProductSerializer,
     ServerToClientProductSerializer,
     ServerToClientOrderSerializer)
 from inventario_app.models import Order, Product
@@ -43,15 +43,6 @@ def getActiveOrder(request):
 def orderDetail(request, pk):
     order = Order.objects.get(id=pk)
     serializer = OrderSerializer(order)
-    return Response(serializer.data)
-
-@api_view(['POST'])
-def orderCreate(request):
-    serializer = OrderSerializer(data=request.data)
-    if serializer.is_valid():
-        serializer.save()
-    else:
-        print("SANTI: La validacion fallo")
     return Response(serializer.data)
 
 @api_view(['POST'])
@@ -96,6 +87,3 @@ def getMostPopularProducts(request):
 #         products = Product.objects.all()
 #         most_popular = Product.objects.all().order_by("-views")[:4]
 #         return list(chain(products, most_popular))
-
-
-

--- a/inventario_app/forms.py
+++ b/inventario_app/forms.py
@@ -10,11 +10,7 @@ class CreateProductForm(ModelForm):
 
 class EmailConfirmationForm(forms.Form):
     name = forms.CharField(max_length=100, required=True, label='Nombre')
-    surename = forms.CharField(max_length=100, required=True, label='Apellido')
+    surname = forms.CharField(max_length=100, required=True, label='Apellido')
     email = forms.EmailField(required=True)
     phone_number = forms.CharField(max_length=20, label='Telefono')
-
-
-       
-
-        
+    order_items = forms.JSONField(widget=forms.HiddenInput())

--- a/static/js/email_confirmation.js
+++ b/static/js/email_confirmation.js
@@ -1,56 +1,12 @@
 order = JSON.parse(localStorage.getItem('order'))
 
-final_order = {
-    "complete": false,
-    "active": true,
-    "customer_name": " ",
-    "customer_email": " ",
-    "items": [],
-}
-
-Object.values(order).forEach((i) =>{
-    console.log("item", i)
-    final_order.items.push({
+order_items = []
+Object.values(order).forEach((i) => {
+    order_items.push({
         'id': i.id,
         'quantity': i.quantity,
         })
     });
 
-console.log('final order', final_order)
-
-const form = document.getElementById('form')
-const csrftoken = form.getElementsByTagName('input')[0].value
-
-
-function createOrderItem(order){
-    console.log('Esta es la funcion createOrderItem')
-
-    const url = '/api/order-create/'
-
-	fetch(url, {
-        method: 'POST',
-        body: JSON.stringify(final_order),
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': csrftoken,
-        }
-    }).then(res => res.json())
-    .catch(error => console.error('Error', error))
-    .then(response => console.log('Success', response));
-
-}
-document.getElementById('enviar-button').addEventListener('click', (event) => {
-    if(JSON.parse(localStorage.getItem('total_quantity')) >0 ){
-        const name = form.getElementsByTagName('input')[1].value
-        const last_name = form.getElementsByTagName('input')[2].value
-        const email = form.getElementsByTagName('input')[3].value
-        final_order.customer_name = `${name} ${last_name}`
-        final_order.customer_email = email
-        createOrderItem(final_order)
-    }else{
-        event.preventDefault()
-        let message = document.querySelector('#order-empty-message')
-        message.classList.add('show')
-        console.log('la orden esta vacia')
-    }
-});
+document.getElementById('id_order_items')
+    .setAttribute("value", JSON.stringify(order_items));


### PR DESCRIPTION
Before this change, a javascript listener would generate the
order when the submit button was clicked, without any associated
validations.

This change puts the order contents as a form hidden field and
executes the order request as a result of the POST request occurred
when the form is submitted.

Note: This approach has the added advantage of having the order
be a snapshot of what the cart was at the moment of navigating
to the "confirm e-mail" screen.

Pending action items:
- When the order submits successfuly, clear the localstorage.
  This is a known limitation of this change.
- In the confirmation screen, we should also provide the user
  with a summary of the order like the one in the previous
  screen, but obtaining product data from the server, instead
  of local storage (prices could be out of date, etc).

Issue: #14